### PR TITLE
Implement path resolution that accounts for shadow copying

### DIFF
--- a/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
+++ b/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
@@ -10,7 +10,7 @@ namespace PDFtoImage.PdfiumViewer
         static NativeMethods()
         {
             // Load the platform dependent Pdfium.dll if it exists.
-            LoadNativeLibrary(Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().GetName(false).CodeBase).LocalPath)!);
+            LoadNativeLibrary(Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().GetName(false).CodeBase!).LocalPath)!);
         }
 
         private static string? _pdfiumLibPath;

--- a/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
+++ b/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
@@ -10,7 +10,7 @@ namespace PDFtoImage.PdfiumViewer
         static NativeMethods()
         {
             // Load the platform dependent Pdfium.dll if it exists.
-            LoadNativeLibrary(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!);
+            LoadNativeLibrary(Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().GetName(false).CodeBase).LocalPath)!);
         }
 
         private static string? _pdfiumLibPath;


### PR DESCRIPTION
Fixes #2. There might be a better way of getting the bin folder that works across all conceivable execution contexts.