### PR TITLE
Update NativeMethods.cs

### DIFF
--- a/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
+++ b/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
@@ -15,6 +15,8 @@ namespace PDFtoImage.PdfiumViewer
                 Assembly.GetExecutingAssembly().GetName(false).CodeBase
                 ?? Process.GetCurrentProcess().MainModule!.FileName!;
 
+            workingDirectory = workingDirectory ?? AppContext.BaseDirectory;
+
             LoadNativeLibrary(Path.GetDirectoryName(new Uri(workingDirectory).LocalPath)!);
         }
 


### PR DESCRIPTION
In Docker (ubuntu 20.04), when .net console  app with PDFtoImage is call from another application, 
`workingDirectory` is not setup. 

new line 
            workingDirectory = workingDirectory ?? AppContext.BaseDirectory;

adds starting directory of application and fixes the issue. 
