### PR TITLE
Update NativeMethods.cs

### DIFF
--- a/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
+++ b/src/PDFtoImage/PdfiumViewer/NativeMethods.cs
@@ -13,7 +13,8 @@ namespace PDFtoImage.PdfiumViewer
             // Load the platform dependent Pdfium.dll if it exist.
             var workingDirectory =
                 Assembly.GetExecutingAssembly().GetName(false).CodeBase
-                ?? Process.GetCurrentProcess().MainModule!.FileName!;
+                ?? Process.GetCurrentProcess().MainModule!.FileName!
+                ?? AppContext.BaseDirectory;
 
             LoadNativeLibrary(Path.GetDirectoryName(new Uri(workingDirectory).LocalPath)!);
         }


### PR DESCRIPTION
In Docker (ubuntu 20.04), when .net console app with PDFtoImage is call from another application,
workingDirectory is not setup.

new line
workingDirectory = workingDirectory ?? AppContext.BaseDirectory;

adds starting directory of application and fixes the issue.