### PR TITLE
Fix color issue on MacOS and Android by specifying SKColorType

### DIFF
--- a/src/PDFtoImage/PdfiumViewer/PdfDocument.cs
+++ b/src/PDFtoImage/PdfiumViewer/PdfDocument.cs
@@ -75,7 +75,7 @@ namespace PDFtoImage.PdfiumViewer
                 height = height * (int)dpiY / 72;
             }
 
-            var bitmap = new SKBitmap(width, height);
+            var bitmap = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
             var handle = NativeMethods.FPDFBitmap_CreateEx(width, height, 4, bitmap.GetPixels(), width * 4);
 
             try


### PR DESCRIPTION
This pull request addresses a color inconsistency issue observed on MacOS and Android platforms when rendering PDF files into images.
The problem manifested as an incorrect color interpretation, where, for example, red was displayed as blue. (With Windows and Linux (Ubuntu) the colors were correct.)
The following old issue should be the same problem: https://github.com/sungaila/PDFtoImage/issues/17

Changes:
SKBitmap Creation: Updated the creation of SKBitmap in the Render method of PdfDocument.cs by specifying the SKColorType as Bgra8888 and SKAlphaType as Premul.

Rationale:
SKColorType.Bgra8888: Ensures that the color channels are interpreted in the order Blue, Green, Red, Alpha, matching the expected color layout.
SKAlphaType.Premul: Sets the alpha type to premultiplied, aligning with the expected transparency handling.

Testing:
The change has been tested on Windows, Linux, MacOS and Android (.NET 7) and the color rendering is now consistent across all platforms.

Since for FPDFBitmap_CreateEx the FXDIBFormats is set to 4, which is "4 bytes per pixel, byte order: blue, green, red, alpha", setting the bitmap to Bgra8888 should not cause any problems.
( https://pdfium.patagames.com/help/html/T_Patagames_Pdf_Enums_FXDIBFormats.htm )
Since it was already the expected format.

Impact:
This fix ensures that the PDF-to-image conversion provides consistent color rendering across different platforms, improving the reliability and visual accuracy of the library.