### PR TITLE
Add signed build provenance attestations; update NuGet packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -113,9 +113,8 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@main
         with:
-          subject-path:
-            src/PDFtoImage/bin/${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }}/*.nupkg
-            src/PDFtoImage/bin/${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }}/*.snupkg
+          subject-path: |
+            'src/PDFtoImage/bin/${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }}/*.nupkg'
       - name: Publish libraries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@main
         with:
-          subject-path: 'src/PDFtoImage/bin/**/*'
+          subject-path: 'src/PDFtoImage/bin/**/PDFtoImage.*'
       - name: Publish libraries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -113,7 +113,9 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@main
         with:
-          subject-path: 'src/PDFtoImage/bin/**/PDFtoImage.*'
+          subject-path:
+            src/PDFtoImage/bin/${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }}/*.nupkg
+            src/PDFtoImage/bin/${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }}/*.snupkg
       - name: Publish libraries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -51,6 +51,10 @@ jobs:
     name: Build
     runs-on: windows-latest
     if: (github.event_name != 'workflow_dispatch' && true || inputs.run_build) == true
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@main
@@ -106,6 +110,10 @@ jobs:
         run: msbuild src/PDFtoImage.Build.slnf /p:Configuration=${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }} /p:VersionSuffix=ci /p:RestorePackages=false
       - name: Pack
         run: msbuild src/PDFtoImage/PDFtoImage.csproj /t:pack /p:Configuration=${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }} /p:VersionSuffix=ci /p:RestorePackages=false
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@main
+        with:
+          subject-path: 'src/PDFtoImage/bin/**/*'
       - name: Publish libraries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -113,8 +113,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@main
         with:
-          subject-path: |
-            'src/PDFtoImage/bin/${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }}/*.nupkg'
+          subject-path: src/PDFtoImage/bin/${{ github.event_name != 'workflow_dispatch' && 'Debug' || inputs.build_configuration }}/*.nupkg
       - name: Publish libraries
         uses: actions/upload-artifact@v4
         with:

--- a/src/FrameworkTests/MauiApp/MauiApp.csproj
+++ b/src/FrameworkTests/MauiApp/MauiApp.csproj
@@ -50,8 +50,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.10" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.21" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PDFtoImage/Conversion.cs
+++ b/src/PDFtoImage/Conversion.cs
@@ -24,7 +24,7 @@ namespace PDFtoImage
     [SupportedOSPlatform("macOS")]
     [SupportedOSPlatform("Android31.0")]
 #endif
-    public static partial class Conversion
+    public static class Conversion
     {
         /// <summary>
         /// Renders a single page of a given PDF and saves it as a JPEG.

--- a/src/PDFtoImage/PDFtoImage.csproj
+++ b/src/PDFtoImage/PDFtoImage.csproj
@@ -67,18 +67,18 @@
 
   <!-- SourceLink build steps and NuGet packages -->
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.7" PrivateAssets="analyzers" />
+    <PackageReference Include="SkiaSharp" Version="2.88.8" PrivateAssets="analyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Shared packages -->
   <ItemGroup Condition="'$(TargetFramework)'!='net7.0-android' and '$(TargetFramework)'!='net8.0-android' and '$(TargetFramework)'!='monoandroid10.0'">
-    <PackageReference Include="bblanchon.PDFium.Linux" Version="124.0.6350" PrivateAssets="analyzers" />
-    <PackageReference Include="bblanchon.PDFium.macOS" Version="124.0.6350" PrivateAssets="analyzers" />
-    <PackageReference Include="bblanchon.PDFium.Win32" Version="124.0.6350" PrivateAssets="analyzers" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.7" PrivateAssets="analyzers" />
-    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.7" PrivateAssets="analyzers" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.7" PrivateAssets="analyzers" />
+    <PackageReference Include="bblanchon.PDFium.Linux" Version="126.0.6476" PrivateAssets="analyzers" />
+    <PackageReference Include="bblanchon.PDFium.macOS" Version="126.0.6476" PrivateAssets="analyzers" />
+    <PackageReference Include="bblanchon.PDFium.Win32" Version="126.0.6476" PrivateAssets="analyzers" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" PrivateAssets="analyzers" />
+    <PackageReference Include="SkiaSharp.NativeAssets.macOS" Version="2.88.8" PrivateAssets="analyzers" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="2.88.8" PrivateAssets="analyzers" />
   </ItemGroup>
 
   <!-- .NET Framework packages -->
@@ -94,14 +94,14 @@
 
   <!-- Android packages -->
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0-android' or '$(TargetFramework)'=='net8.0-android' or '$(TargetFramework)'=='monoandroid10.0'">
-    <PackageReference Include="bblanchon.PDFium.Android" Version="124.0.6350" PrivateAssets="analyzers" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Android" Version="2.88.7" PrivateAssets="analyzers" />
+    <PackageReference Include="bblanchon.PDFium.Android" Version="126.0.6476" PrivateAssets="analyzers" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Android" Version="2.88.8" PrivateAssets="analyzers" />
   </ItemGroup>
 
   <!-- Blazor WebAssembly stuff -->
   <ItemGroup Condition="'$(TargetFramework)'=='net7.0' or '$(TargetFramework)'=='net8.0'">
-    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.7" PrivateAssets="analyzers" />
-    <PackageReference Include="Sungaila.PDFium.BlazorWebAssembly" Version="124.0.6350" PrivateAssets="analyzers" />
+    <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="2.88.8" PrivateAssets="analyzers" />
+    <PackageReference Include="Sungaila.PDFium.BlazorWebAssembly" Version="126.0.6476" PrivateAssets="analyzers" />
   </ItemGroup>
 
   <Import Project="PDFtoImage.PropertiesSigning.targets" />

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -8138,7 +8138,7 @@
   <!-- NuGet Icon -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
 </Project>

--- a/src/WebConverter/WebConverter.csproj
+++ b/src/WebConverter/WebConverter.csproj
@@ -39,9 +39,9 @@
 
   <ItemGroup>
     <PackageReference Include="ByteSize" Version="2.1.2" />
-    <PackageReference Include="Markdig.Signed" Version="0.36.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.3" PrivateAssets="all" />
+    <PackageReference Include="Markdig.Signed" Version="0.37.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.4" PrivateAssets="all" />
     <PackageReference Include="Thinktecture.Blazor.FileHandling" Version="2.0.0" />
     <PackageReference Include="Thinktecture.Blazor.WebShare" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Adds [signed build provenance attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) for workflow artifacts.

Also updates all NuGet packages to current version.