### PR TITLE
update dependencies for MS 26-05 security patches

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,15 +11,15 @@
     <PackageVersion Include="bblanchon.PDFium.Win32" Version="148.0.7776" />
     <PackageVersion Include="ByteSize" Version="2.1.2" />
     <PackageVersion Include="Markdig.Signed" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.51" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.51" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.60" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.60" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.2.2" />
     <PackageVersion Include="PatrickJahr.Blazor.FileHandling" Version="1.0.0" />
     <PackageVersion Include="PatrickJahr.Blazor.WebShare" Version="1.0.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />


### PR DESCRIPTION
Hello @sungaila,

I noticed that the **MS 26-05 security patches** have been released for Microsoft-managed NuGet packages. Since the recent Dependabot run appears to have failed, I have manually created this PR to bump the versions for the following packages.

My team and I find this project incredibly useful for converting exported PDF reports into image files. We truly appreciate your work on this project!

**Dependency updates:**

* Upgraded `Microsoft.AspNetCore.Components.WebAssembly` and `Microsoft.AspNetCore.Components.WebAssembly.DevServer` from `10.0.5` to `10.0.8`.
* Upgraded `Microsoft.Extensions.Logging.Debug` from `10.0.5` to `10.0.8`.
* Upgraded `Microsoft.Maui.Controls` and `Microsoft.Maui.Controls.Compatibility` from `10.0.51` to `10.0.60`.

**Testing framework updates:**

* Upgraded `Microsoft.NET.Test.Sdk` from `18.3.0` to `18.5.1`.
* Upgraded `MSTest.TestAdapter` and `MSTest.TestFramework` from `4.1.0` to `4.2.2`.